### PR TITLE
.gitignore file for common items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,55 @@
+.DS_Store
+.idea
+__pycache__/
+*.py[cod]
+db.sqlite3
+migrations/
+media/
+settings.py
+
+# C extensions
+*.so
+
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+docs/_build/
+
+target/


### PR DESCRIPTION
This is for work done in PyCharm or IntelliJ, work done on MacOS, and covers any building, unit testing, and Django logs. 